### PR TITLE
Add namespace

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,7 +31,7 @@ android {
     compileSdkVersion 31
 
     defaultConfig {
-        minSdkVersion 23
+        minSdkVersion 31
         targetSdkVersion 34
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,6 +24,8 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace "com.shadyboshra2012.flutter_checkout_payment"
+    
     compileSdkVersion 29
 
     defaultConfig {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,10 +28,11 @@ android {
         namespace "com.shadyboshra2012.flutter_checkout_payment"
     }
     
-    compileSdkVersion 29
+    compileSdkVersion 31
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 23
+        targetSdkVersion 34
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,7 +24,9 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    namespace "com.shadyboshra2012.flutter_checkout_payment"
+    if (project.android.hasProperty("namespace")) {
+        namespace "com.shadyboshra2012.flutter_checkout_payment"
+    }
     
     compileSdkVersion 29
 


### PR DESCRIPTION
Without this fix you get this error when using the latest Gradle major version (8)

```
* What went wrong:
A problem occurred configuring project ':flutter_checkout_payment'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.

     If you've specified the package attribute in the source AndroidManifest.xml, you can use the AGP Upgrade Assistant to migrate to the namespace value in the build file. Refer to https://d.android.com/r/tools/upgrade-assistant/agp-upgrade-assistant for general information about using the AGP Upgrade Assistant.
```