### PR TITLE
Remove Flutter v1 embedding to fix Android compilation

### DIFF
--- a/android/src/main/java/com/shadyboshra2012/flutter_checkout_payment/FlutterCheckoutPaymentPlugin.java
+++ b/android/src/main/java/com/shadyboshra2012/flutter_checkout_payment/FlutterCheckoutPaymentPlugin.java
@@ -28,7 +28,6 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 import kotlin.Unit;
 import org.jetbrains.annotations.NotNull;
 
@@ -91,21 +90,6 @@ public class FlutterCheckoutPaymentPlugin implements FlutterPlugin, MethodCallHa
     @Override
     public void onDetachedFromActivity() {
         activity = null;
-    }
-
-    // This static function is optional and equivalent to onAttachedToEngine. It supports the old
-    // pre-Flutter-1.12 Android projects. You are encouraged to continue supporting
-    // plugin registration via this function while apps migrate to use the new Android APIs
-    // post-flutter-1.12 via https://flutter.dev/go/android-project-migration.
-    //
-    // It is encouraged to share logic between onAttachedToEngine and registerWith to keep
-    // them functionally equivalent. Only one of onAttachedToEngine or registerWith will be called
-    // depending on the user's project. onAttachedToEngine or registerWith must both be defined
-    // in the same class.
-    public static void registerWith(Registrar registrar) {
-        final MethodChannel channel = new MethodChannel(registrar.messenger(), CHANNEL_NAME);
-        channel.setMethodCallHandler(new FlutterCheckoutPaymentPlugin());
-        context = registrar.context();
     }
 
     @Override


### PR DESCRIPTION
Since Flutter 3.29, Android Registrar api is not supported anymore causing Android builds to fail by throwing the following error

```
/Users/user/.pub-cache/hosted/pub.dev/flutter_checkout_payment-1.4.3/android/src/main/java/com/shadyboshra2012/flutter_checkout_payment/FlutterCheckoutPaymentPlugin.java:31: error: cannot find symbol
import io.flutter.plugin.common.PluginRegistry.Registrar;
                                              ^
  symbol:   class Registrar
  location: interface PluginRegistry
/Users/user/.pub-cache/hosted/pub.dev/flutter_checkout_payment-1.4.3/android/src/main/java/com/shadyboshra2012/flutter_checkout_payment/FlutterCheckoutPaymentPlugin.java:105: error: cannot find symbol
    public static void registerWith(Registrar registrar) {
                                    ^
  symbol:   class Registrar
  location: class FlutterCheckoutPaymentPlugin
Note: /Users/user/.pub-cache/hosted/pub.dev/flutter_checkout_payment-1.4.3/android/src/main/java/com/shadyboshra2012/flutter_checkout_payment/FlutterCheckoutPaymentPlugin.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: /Users/user/.pub-cache/hosted/pub.dev/flutter_checkout_payment-1.4.3/android/src/main/java/com/shadyboshra2012/flutter_checkout_payment/FlutterCheckoutPaymentPlugin.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
2 errors

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':flutter_checkout_payment:compileDebugJavaWithJavac'.
> Compilation failed; see the compiler error output for details.
```